### PR TITLE
fix: 修复代码审查指出的 Critical / Major / Minor 问题

### DIFF
--- a/SyncTheSpire/Handlers/ConfigHandler.cs
+++ b/SyncTheSpire/Handlers/ConfigHandler.cs
@@ -78,6 +78,7 @@ public class ConfigHandler : HandlerBase
                 isJunctionActive = false,
                 hasLocalChanges = false,
                 customExePath = ws.CustomExePath,
+                credentialsLost = ws.CredentialsLost,
                 capabilities
             };
         }
@@ -96,6 +97,7 @@ public class ConfigHandler : HandlerBase
                 hasLocalChanges = isInit ? false : _gitService.HasLocalChanges(),
                 needsBranchSelection = isInit,
                 customExePath = ws.CustomExePath,
+                credentialsLost = ws.CredentialsLost,
                 capabilities
             };
         }
@@ -256,6 +258,8 @@ public class ConfigHandler : HandlerBase
         ws.GameInstallPath = cfg.GameInstallPath;
         ws.GameModPathLegacy = cfg.GameModPathLegacy;
         ws.SaveFolderPath = cfg.SaveFolderPath;
+        // user re-entered credentials; clear the "decrypt failed" flag
+        ws.CredentialsLost = false;
         _configService.SaveWorkspace();
 
         // resolve the actual target path — adapter decides if it's {install}\Mods or install itself

--- a/SyncTheSpire/Handlers/ConfigHandler.cs
+++ b/SyncTheSpire/Handlers/ConfigHandler.cs
@@ -13,7 +13,8 @@ namespace SyncTheSpire.Handlers;
 public class ConfigHandler : HandlerBase
 {
     private readonly ConfigService _configService;
-    private readonly GitService _gitService;
+    // null when there's no active workspace (stub state). all callers must null-check.
+    private readonly GitService? _gitService;
     private readonly JunctionService _junctionService;
     private readonly JunctionHelper _junctionHelper;
     private readonly IGameAdapter _adapter;
@@ -23,7 +24,7 @@ public class ConfigHandler : HandlerBase
         CoreWebView2 webView,
         SynchronizationContext uiContext,
         ConfigService configService,
-        GitService gitService,
+        GitService? gitService,
         JunctionService junctionService,
         JunctionHelper junctionHelper,
         IGameAdapter adapter,
@@ -185,6 +186,11 @@ public class ConfigHandler : HandlerBase
             return;
         }
 
+        // INIT_CONFIG always runs after MessageRouter rebuilds handlers with a real
+        // workspace context, so _gitService is guaranteed non-null here.
+        var gitService = _gitService
+            ?? throw new InvalidOperationException("GitService 未初始化，请先创建工作区");
+
         var raw = payload.Value.GetRawText();
         var cfg = JsonSerializer.Deserialize<WorkspaceConfig>(raw);
         if (cfg is null)
@@ -257,10 +263,10 @@ public class ConfigHandler : HandlerBase
 
         // check if remote URL changed — if so, nuke the old repo and re-clone
         // (could be a completely different repo, can't just update the remote)
-        var needsClone = !_gitService.IsRepoValid;
+        var needsClone = !gitService.IsRepoValid;
         if (!needsClone)
         {
-            var currentUrl = _gitService.GetCurrentRemoteUrl();
+            var currentUrl = gitService.GetCurrentRemoteUrl();
             if (!string.Equals(currentUrl, cfg.RepoUrl, StringComparison.Ordinal))
                 needsClone = true;
         }
@@ -270,9 +276,9 @@ public class ConfigHandler : HandlerBase
             Send(IpcResponse.Progress("INIT_CONFIG", "正在从远程仓库拉取文件，请稍候..."));
 
             // wire up real-time progress from git transfer + LFS warnings during post-clone auto-detect
-            _gitService.OnTransferProgress = p =>
+            gitService.OnTransferProgress = p =>
                 Send(IpcResponse.Progress("INIT_CONFIG", $"正在从远程仓库拉取文件... {p.Percent}%", p.Percent, p.Detail));
-            _gitService.OnLfsMessage = msg =>
+            gitService.OnLfsMessage = msg =>
                 Send(IpcResponse.Progress("INIT_CONFIG", msg));
 
             if (_adapter.SupportsJunction)
@@ -291,7 +297,7 @@ public class ConfigHandler : HandlerBase
 
                 try
                 {
-                    _gitService.CloneRepo();
+                    gitService.CloneRepo();
                 }
                 catch
                 {
@@ -323,11 +329,11 @@ public class ConfigHandler : HandlerBase
                 FileSystemHelper.ForceDeleteDirectory(_configService.RepoPath);
                 FileSystemHelper.ForceDeleteDirectory(_configService.GitDirPath);
 
-                _gitService.CloneRepo();
+                gitService.CloneRepo();
             }
 
-            _gitService.OnTransferProgress = null;
-            _gitService.OnLfsMessage = null;
+            gitService.OnTransferProgress = null;
+            gitService.OnLfsMessage = null;
         }
 
         // junction mode: link game folder to repo working tree

--- a/SyncTheSpire/Handlers/GitBranchHandler.cs
+++ b/SyncTheSpire/Handlers/GitBranchHandler.cs
@@ -51,11 +51,14 @@ public class GitBranchHandler : HandlerBase
             return;
         }
 
-        var branches = _gitService.GetRemoteBranches();
+        // share a single Repository across branch listing + NSFW scan to avoid
+        // double-opening (LibGit2Sharp init takes file lock + loads index)
+        using var repo = _gitService.OpenRepository();
+        var branches = _gitService.GetRemoteBranches(repo);
         var current = _gitService.GetCurrentBranch();
 
         // scan all branches for NSFW signals (folder names, mod names, etc.)
-        var nsfwMap = _nsfwDetection.CheckBranchesNsfw(branches.Select(b => b.Name));
+        var nsfwMap = _nsfwDetection.CheckBranchesNsfw(branches.Select(b => b.Name), repo);
 
         // flatten BranchInfo to plain objects so JSON stays predictable
         var list = branches.Select(b =>

--- a/SyncTheSpire/Models/WorkspaceConfig.cs
+++ b/SyncTheSpire/Models/WorkspaceConfig.cs
@@ -95,4 +95,12 @@ public class WorkspaceConfig
             "anonymous" => true,
             _ => false
         };
+
+    /// <summary>
+    /// runtime-only flag (not persisted): set when DPAPI decrypt failed during load.
+    /// indicates token/passphrase were dropped and the user must re-enter them before
+    /// auth-requiring git operations can succeed.
+    /// </summary>
+    [JsonIgnore]
+    public bool CredentialsLost { get; set; }
 }

--- a/SyncTheSpire/Services/GitService.cs
+++ b/SyncTheSpire/Services/GitService.cs
@@ -164,9 +164,10 @@ public class GitService
         ConfigureGitEnv(psi);
 
         using var proc = Process.Start(psi)!;
-        // read stderr async to avoid deadlock when pipe buffer fills
+        // read both streams async — sync read on either stream would deadlock when pipe
+        // buffer fills (e.g. ls-files / branch --format on large repos)
         var stderrTask = proc.StandardError.ReadToEndAsync();
-        var stdout = proc.StandardOutput.ReadToEnd();
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
 
         if (!proc.WaitForExit(timeout))
         {
@@ -174,6 +175,7 @@ public class GitService
             throw new InvalidOperationException($"git {psi.ArgumentList.FirstOrDefault()} timed out after {timeout / 1000}s");
         }
 
+        var stdout = stdoutTask.Result;
         var stderr = stderrTask.Result;
         if (proc.ExitCode != 0)
             throw new InvalidOperationException($"git {psi.ArgumentList.FirstOrDefault()} failed: {stderr.Trim()}");
@@ -293,8 +295,9 @@ public class GitService
         ConfigureGitEnv(psi);
 
         using var proc = Process.Start(psi)!;
+        // read both streams async to avoid pipe-buffer deadlock when output is large
         var stderrTask = proc.StandardError.ReadToEndAsync();
-        var stdout = proc.StandardOutput.ReadToEnd();
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
 
         if (!proc.WaitForExit(timeout))
         {
@@ -302,6 +305,7 @@ public class GitService
             throw new InvalidOperationException($"git-lfs {psi.ArgumentList.FirstOrDefault()} timed out after {timeout / 1000}s");
         }
 
+        var stdout = stdoutTask.Result;
         var stderr = stderrTask.Result;
         if (proc.ExitCode != 0)
             throw new InvalidOperationException($"git-lfs {psi.ArgumentList.FirstOrDefault()} failed: {stderr.Trim()}");
@@ -989,7 +993,8 @@ public class GitService
 
             // open fresh repo view (migrate rewrote history, previous SHA references are stale)
             using var repo = OpenRepo();
-            var localTip = repo.Head.Tip.Sha;
+            var localTip = repo.Head.Tip?.Sha
+                ?? throw new InvalidOperationException($"分支 {br} 没有任何提交，无法推送");
 
             LogService.Info($"LFS migration complete for {br}, force pushing");
             RunGitCli($"push --force-with-lease -u origin \"{br}\"", timeout: 300_000);
@@ -997,9 +1002,13 @@ public class GitService
             LogService.Info($"LFS migration push verified for {br}");
         }
 
-        // restore original branch if it exists and wasn't in the migration set
+        // restore original branch if it exists and wasn't in the migration set —
+        // best-effort but log the reason so a corrupted repo / disk-full doesn't go silent
         if (!string.IsNullOrEmpty(savedBranch) && savedBranch != InitBranch && !branches.Contains(savedBranch))
-            try { RunGitCli($"checkout \"{savedBranch}\""); } catch { }
+        {
+            try { RunGitCli($"checkout \"{savedBranch}\""); }
+            catch (Exception ex) { LogService.Warn($"Failed to restore branch {savedBranch}: {ex.Message}"); }
+        }
     }
 
     // detect LFS filter rules in .gitattributes and install git-lfs hooks if found.
@@ -1246,6 +1255,10 @@ public class GitService
     /// <summary>
     /// run git.exe fetch with one retry on auth failure — credential helpers
     /// (e.g. GCM) may need a warm-up round on first invocation after app start.
+    /// the 1s wait is rare (only on first auth failure) and we're already inside
+    /// a Task.Run dispatched from MessageRouter, so blocking a thread-pool thread
+    /// once per fetch retry is acceptable; converting the whole call chain to
+    /// async would touch dozens of methods for negligible gain.
     /// </summary>
     private void RunGitCliFetch()
     {
@@ -1256,6 +1269,7 @@ public class GitService
         catch (InvalidOperationException ex) when (ex.Message.Contains("Authentication failed"))
         {
             LogService.Warn("git.exe fetch auth failed, retrying after credential helper warm-up...");
+            // sync sleep is intentional — see method-level comment above
             Thread.Sleep(1000);
             RunGitCliWithProgress("fetch --all --prune --progress");
         }
@@ -1288,7 +1302,8 @@ public class GitService
             throw new InvalidOperationException(
                 $"远端地址不一致，期望 \"{ws.RepoUrl}\"，实际为 \"{remote.Url}\"。请重新初始化配置。");
 
-        var localTip = repo.Head.Tip.Sha;
+        var localTip = repo.Head.Tip?.Sha
+            ?? throw new InvalidOperationException("当前分支没有任何提交，无法推送");
         var branchName = repo.Head.FriendlyName;
         LogService.Info($"Pushing branch {branchName} to origin");
 
@@ -1361,7 +1376,8 @@ public class GitService
             throw new InvalidOperationException(
                 $"远端地址不一致，期望 \"{ws.RepoUrl}\"，实际为 \"{remote.Url}\"。请重新初始化配置。");
 
-        var localTip = repo.Head.Tip.Sha;
+        var localTip = repo.Head.Tip?.Sha
+            ?? throw new InvalidOperationException("当前分支没有任何提交，无法推送");
         var branchName = repo.Head.FriendlyName;
         LogService.Info($"Force pushing branch {branchName} (--force-with-lease)");
 

--- a/SyncTheSpire/Services/GitService.cs
+++ b/SyncTheSpire/Services/GitService.cs
@@ -317,6 +317,13 @@ public class GitService
     /// </summary>
     private Repository OpenRepo() => new(GitDirPath);
 
+    /// <summary>
+    /// expose Repository ownership to handlers that need to make multiple queries
+    /// in a single batch (e.g. branch list + NSFW scan), avoiding repeated open cost.
+    /// caller is responsible for disposing.
+    /// </summary>
+    public Repository OpenRepository() => OpenRepo();
+
     // ── clone ────────────────────────────────────────────────────────────
 
     public void CloneRepo()
@@ -400,7 +407,15 @@ public class GitService
     public List<BranchInfo> GetRemoteBranches()
     {
         using var repo = OpenRepo();
+        return GetRemoteBranches(repo);
+    }
 
+    /// <summary>
+    /// list remote branches reusing a caller-supplied Repository. lets handlers batch
+    /// branch listing with other queries (e.g. NSFW scan) in one open repo session.
+    /// </summary>
+    public List<BranchInfo> GetRemoteBranches(Repository repo)
+    {
         // fetch first so we have the latest refs
         FetchAll(repo);
 

--- a/SyncTheSpire/Services/MessageRouter.cs
+++ b/SyncTheSpire/Services/MessageRouter.cs
@@ -120,7 +120,8 @@ public class MessageRouter
             var stubJH = new JunctionHelper(_junctionService, stubBackup, Send);
             var stubAdapter = GameAdapterRegistry.Get("sts2");
 
-            _configHandler = new ConfigHandler(_webView, _uiContext, stubCs, null!, _junctionService, stubJH, stubAdapter, _workspaceManager);
+            // pass null for GitService — ConfigHandler now accepts GitService? and null-checks all reads
+            _configHandler = new ConfigHandler(_webView, _uiContext, stubCs, null, _junctionService, stubJH, stubAdapter, _workspaceManager);
             _gitBranchHandler = null;
             _saveHandler = null;
             _redirectHandler = new RedirectHandler(_webView, _uiContext, stubCs, _junctionService, stubAdapter);

--- a/SyncTheSpire/Services/ModInstallService.cs
+++ b/SyncTheSpire/Services/ModInstallService.cs
@@ -15,6 +15,10 @@ public class ModInstallService
         PropertyNameCaseInsensitive = true
     };
 
+    // soft cap on cumulative extracted size — defends against zip-bomb archives
+    // (a few KB compressed expanding to GBs). 2 GiB is well above any legitimate mod.
+    private const long MaxExtractedSize = 2L * 1024 * 1024 * 1024;
+
     private readonly ModScannerService _modScanner;
 
     public ModInstallService(ModScannerService modScanner)
@@ -64,6 +68,7 @@ public class ModInstallService
             throw new InvalidOperationException("压缩包中未找到有效的 MOD 定义文件（需要包含 id 字段的 .json 文件）");
 
         var installed = new List<string>();
+        long totalExtracted = 0;
 
         foreach (var (mod, manifestKey, modRoot) in manifests)
         {
@@ -123,9 +128,21 @@ public class ModInstallService
                 var fileDir = Path.GetDirectoryName(fileDest);
                 if (fileDir != null) Directory.CreateDirectory(fileDir);
 
+                // copy with running-total guard so a malicious archive can't fill the disk —
+                // entry.Size is unreliable (uncompressed size from header may be spoofed),
+                // so we count actual bytes written and abort partway through if we exceed the cap
                 using var entryStream = entry.OpenEntryStream();
                 using var fs = File.Create(fileDest);
-                entryStream.CopyTo(fs);
+                var buffer = new byte[81920];
+                int read;
+                while ((read = entryStream.Read(buffer, 0, buffer.Length)) > 0)
+                {
+                    totalExtracted += read;
+                    if (totalExtracted > MaxExtractedSize)
+                        throw new InvalidOperationException(
+                            $"压缩包解压后大小超过限制（{MaxExtractedSize / (1024 * 1024 * 1024)} GiB），可能是异常压缩包，已中止");
+                    fs.Write(buffer, 0, read);
+                }
             }
 
             installed.Add(mod.Name ?? mod.Id!);

--- a/SyncTheSpire/Services/NsfwDetectionService.cs
+++ b/SyncTheSpire/Services/NsfwDetectionService.cs
@@ -31,11 +31,21 @@ public class NsfwDetectionService
 
     /// <summary>
     /// scan each branch for NSFW signals: branch name, folder names, and mod names.
-    /// pure object-db read, no checkout involved.
+    /// pure object-db read, no checkout involved. opens a fresh Repository — for callers
+    /// that already have one, prefer the overload that takes an external Repository.
     /// </summary>
     public Dictionary<string, NsfwResult> CheckBranchesNsfw(IEnumerable<string> branchNames)
     {
         using var repo = OpenRepo();
+        return CheckBranchesNsfw(branchNames, repo);
+    }
+
+    /// <summary>
+    /// same as CheckBranchesNsfw but reuses a caller-supplied Repository to avoid
+    /// the file-lock + index-load cost of opening one per call (HandleGetBranches is hot).
+    /// </summary>
+    public Dictionary<string, NsfwResult> CheckBranchesNsfw(IEnumerable<string> branchNames, Repository repo)
+    {
         var result = new Dictionary<string, NsfwResult>();
 
         foreach (var name in branchNames)

--- a/SyncTheSpire/Services/WorkspaceManager.cs
+++ b/SyncTheSpire/Services/WorkspaceManager.cs
@@ -107,6 +107,14 @@ public class WorkspaceManager
                 GameInstallPath = ws.GameInstallPath,
                 GameModPathLegacy = ws.GameModPathLegacy,
                 SaveFolderPath = ws.SaveFolderPath,
+                LfsEnabled = ws.LfsEnabled,
+                LfsTrackedPatterns = [..ws.LfsTrackedPatterns],
+                ExcludedLargeFiles = [..ws.ExcludedLargeFiles],
+                MaxFileSizeMode = ws.MaxFileSizeMode,
+                MaxFileSizeManualMib = ws.MaxFileSizeManualMib,
+                CustomExePath = ws.CustomExePath,
+                RepoPathOverride = ws.RepoPathOverride,
+                GitDirPathOverride = ws.GitDirPathOverride,
             }).ToList(),
         };
 

--- a/SyncTheSpire/Services/WorkspaceManager.cs
+++ b/SyncTheSpire/Services/WorkspaceManager.cs
@@ -75,11 +75,19 @@ public class WorkspaceManager
             _config = new AppConfigV2();
         }
 
-        // decrypt secrets for all workspaces
+        // decrypt secrets for all workspaces — track which ones lost their credentials
+        // so the UI can prompt the user to re-enter rather than failing on the next push
+        // with an opaque "Authentication failed"
         foreach (var ws in _config.Workspaces)
         {
-            ws.Token = DpapiDecrypt(ws.Token);
-            ws.SshPassphrase = DpapiDecrypt(ws.SshPassphrase);
+            ws.Token = DpapiDecrypt(ws.Token, out var tokenFailed);
+            ws.SshPassphrase = DpapiDecrypt(ws.SshPassphrase, out var sshFailed);
+            if (tokenFailed || sshFailed)
+            {
+                LogService.Warn(
+                    $"Workspace {ws.Id} ({ws.Name}): DPAPI decrypt failed for {(tokenFailed ? "token" : "")}{(tokenFailed && sshFailed ? "+" : "")}{(sshFailed ? "ssh-passphrase" : "")} — user must re-enter credentials");
+                ws.CredentialsLost = true;
+            }
         }
     }
 
@@ -152,9 +160,10 @@ public class WorkspaceManager
             return;
         }
 
-        // decrypt v1 secrets
-        v1.Token = DpapiDecrypt(v1.Token);
-        v1.SshPassphrase = DpapiDecrypt(v1.SshPassphrase);
+        // decrypt v1 secrets — track failures so the migrated workspace can flag CredentialsLost
+        v1.Token = DpapiDecrypt(v1.Token, out var v1TokenFailed);
+        v1.SshPassphrase = DpapiDecrypt(v1.SshPassphrase, out var v1SshFailed);
+        var v1CredsLost = v1TokenFailed || v1SshFailed;
 
         // 3. create workspace config from v1
         var wsId = Guid.NewGuid().ToString();
@@ -173,6 +182,7 @@ public class WorkspaceManager
             GameInstallPath = v1.GameInstallPath,
             GameModPathLegacy = v1.GameModPathLegacy,
             SaveFolderPath = v1.SaveFolderPath,
+            CredentialsLost = v1CredsLost,
         };
 
         // 4. attempt to move data directories into workspace folder
@@ -479,7 +489,17 @@ public class WorkspaceManager
     }
 
     internal static string DpapiDecrypt(string stored)
+        => DpapiDecrypt(stored, out _);
+
+    /// <summary>
+    /// decrypt a DPAPI-protected string. on failure, sets failed=true and returns empty
+    /// so the caller can surface a "re-enter credentials" prompt instead of silently
+    /// passing an empty password to the next git auth attempt (which produces a generic
+    /// 401 with no diagnostic value).
+    /// </summary>
+    internal static string DpapiDecrypt(string stored, out bool failed)
     {
+        failed = false;
         if (string.IsNullOrEmpty(stored)) return stored;
 
         if (stored.StartsWith(EncPrefix))
@@ -493,6 +513,7 @@ public class WorkspaceManager
             catch (Exception ex)
             {
                 LogService.Warn($"DPAPI decrypt failed: {ex.Message}");
+                failed = true;
                 return string.Empty;
             }
         }


### PR DESCRIPTION
Closes #8

## 概述

回应 #issue-8 的代码审查报告，在一个 PR 内以 5 个独立 commit 交付全部修复：

| Commit | 主题 | 优先级 |
|---|---|---|
| `93d4e0c` | fix(config): SaveConfig 补齐 LFS / 路径覆写 / 文件大小限制等字段 | P0 |
| `f1ea342` | fix(git): RunGitCli stdout 死锁、Head.Tip null 安全、空 catch 静默 | P1 |
| `0a403a2` | refactor: 移除 ConfigHandler 的 null! 桩，共享 Repository | P2 |
| `43286d5` | security(mod): InstallFromArchive 增加 zip-bomb 解压上限 | P2 |
| `472c775` | fix(auth): DPAPI 解密失败时上抛 CredentialsLost 标记 | P2 |

## 注意

- Linux 环境无法本地编译（TFM `net10.0-windows`），请在 Windows 上 `dotnet build` 验证。
- PR-E 在 `WorkspaceConfig` 新增了 `CredentialsLost` 属性（`[JsonIgnore]`，不持久化），不影响现有 config.json。
- PR-E 会让前端在 `GET_STATUS` 响应中收到新字段 `credentialsLost`，前端目前未消费，建议后续加 toast 提示用户重输凭据。

Generated with [Claude Code](https://claude.ai/code)